### PR TITLE
ProgressDescriptor.groovy should implement Serializable

### DIFF
--- a/src/groovy/com/macrobit/grails/plugins/attachmentable/core/ajax/ProgressDescriptor.groovy
+++ b/src/groovy/com/macrobit/grails/plugins/attachmentable/core/ajax/ProgressDescriptor.groovy
@@ -14,7 +14,7 @@
  */
 package com.macrobit.grails.plugins.attachmentable.core.ajax
 
-class ProgressDescriptor {
+class ProgressDescriptor implements Serializable {
 
     long bytesRead = 0
     long bytesTotal = 0


### PR DESCRIPTION
The Plugin does not run on Glassfish 3.1 out of the box. I had to change the ProgressDescriptor to implement Serializable, now it works fine. 

My Application, however, now depends on changes I made to the plugin. We do not keep plugins in version control, so after a `clean-all` the change has to be applied again. It would be easier to have this in Plugin. 
